### PR TITLE
Fix for unable to compile since compiler level to 1.7 is fail for usi…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,8 +125,8 @@
 				<version>3.1</version>
 				<inherited>true</inherited>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
You cannot use Lambda expressions (which are used in e.g. UrenFormservice) while using Java 7 which should be java 8 then. (in the compiler plugin below in the pom.xml)